### PR TITLE
4-user-can-manage-courses-with-sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Features
   - [3-user-can-manage-courses](https://trello.com/c/NRBBYXNJ)
     - `rails db:migrate`
+  - [4-user-can-manage-courses-with-sections](https://trello.com/c/GOKlj5sG)
+    - `rails db:migrate`
 - Improvements
 - Bug fixes
 - Growth

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'puma', '~> 5.6.4'
 gem 'babosa', '~> 2.0.0'
 gem 'friendly_id', '~> 5.4.2'
 
+# Act as extensions
+gem 'acts_as_list', '~> 1.0.4'
+
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts_as_list (1.0.4)
+      activerecord (>= 4.2)
     ast (2.4.2)
     babosa (2.0.0)
     bootsnap (1.11.1)
@@ -200,6 +202,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_list (~> 1.0.4)
   babosa (~> 2.0.0)
   bootsnap (>= 1.11.1)
   database_cleaner-active_record (~> 2.0.1)

--- a/README.md
+++ b/README.md
@@ -9,16 +9,21 @@ Things you may want to cover:
   - 2.7.4
 - Dependencies
   - Routes
-    - FriendlyId + Babosa
+    - `friendly_id` + `babosa`
       - For semantic url resource parameters(with ASCII support).
+  - Act as extensions
+    - gem 'acts_as_list'
+      - For sorting data with simple API
+      - I actually prefer some other approaches, for example, using `float` column to store `position`.
+        - `(previous.position + next.position) / 2` is a super simple and performant solution for sorting. However, considering the character of this project, I tend to adapt off-the-shelf solution.
   - Test
-    - factory_bot
+    - `factory_bot`
       - Adapt `factory pattern` for building testing(or development) records in ease.
-    - database_cleaner
+    - `database_cleaner-active_record`
       - Truncate database for each tests, make sure each tests are independent.
-    - shoulda-matchers
+    - `shoulda-matchers`
       - Simple one-liner test syntax.
-    - faker
+    - `faker`
       - Random data generation.
 
 - Configuration

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -32,6 +32,6 @@ class API::V1::CoursesController < API::BaseController
   end
 
   def course_params
-    params.require(:course).permit(:name, :teacher_name, :description)
+    params.require(:course).permit(:name, :teacher_name, :description, sections_attributes: [:id, :name, :position, :_destroy])
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,7 +1,9 @@
 class Course < ApplicationRecord
   extend ::FriendlyId
   friendly_id :name_and_date_of_today, use: :slugged
+  has_many :sections, dependent: :delete_all
   validates_presence_of :name, :teacher_name
+  accepts_nested_attributes_for :sections, allow_destroy: true
 
   def name_and_date_of_today
     "#{name}-#{Date.today.strftime('%F')}"

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,0 +1,10 @@
+class Section < ApplicationRecord
+  belongs_to :course
+  acts_as_list scope: :course, top_of_list: 0
+  validates_presence_of :name, :position
+  validates_uniqueness_of :position, scope: :course_id
+  # FIXME: Seems like an issue of acts_as_list_gem
+  # it converts negative value of position to zero automatically
+  # https://github.com/brendon/acts_as_list/issues/269
+  # validates_numericality_of :position, greater_than_or_equal_to: 0
+end

--- a/db/migrate/20220403102934_create_sections.rb
+++ b/db/migrate/20220403102934_create_sections.rb
@@ -1,0 +1,13 @@
+class CreateSections < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sections do |t|
+      t.string :name, null: false
+      t.integer :position, null: false, default: 0
+      t.references :course, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :sections, [:course_id, :name]
+    add_index :sections, [:course_id, :position], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_02_091152) do
+ActiveRecord::Schema.define(version: 2022_04_03_102934) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,4 +25,16 @@ ActiveRecord::Schema.define(version: 2022_04_02_091152) do
     t.index ["slug"], name: "index_courses_on_slug", unique: true
   end
 
+  create_table "sections", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.bigint "course_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["course_id", "name"], name: "index_sections_on_course_id_and_name"
+    t.index ["course_id", "position"], name: "index_sections_on_course_id_and_position", unique: true
+    t.index ["course_id"], name: "index_sections_on_course_id"
+  end
+
+  add_foreign_key "sections", "courses"
 end

--- a/spec/factories/sections.rb
+++ b/spec/factories/sections.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :section do
+    name { Faker::Hobby.activity }
+    position { rand(1...10) }
+    course
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,9 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
+  describe 'associations' do
+    it { should have_many(:sections).dependent(:delete_all) }
+  end
+
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:teacher_name) }
+  end
+
+  describe 'nested_attributes' do
+    it { should accept_nested_attributes_for(:sections).allow_destroy(true) }
   end
 
   describe '#name_and_date_of_today' do

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Section, type: :model do
+  describe 'associations' do
+    it { should belong_to(:course) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:position) }
+
+    describe 'validates_uniqueness_of :position' do
+      subject { build(:section) }
+      it { should validate_uniqueness_of(:position).scoped_to(:course_id) }
+    end
+
+    describe 'validates_numericality_of :position' do
+      it do
+        skip
+        # FIXME: Seems to be an issue with acts_as_list_gem
+        # https://github.com/brendon/acts_as_list/issues/269
+        # it converts negative value of position to zero automatically
+        # So we cannot perform simple one-liner with since it would fail.
+        # section = build(:section, position: -1)
+        # section.position
+        # expect(section.valid?).to be_falsey
+        # expect(section).to validate_numericality_of(:position).is_greater_than_or_equal_to(0)
+      end
+    end
+
+
+  end
+end

--- a/spec/requests/api/v1/courses_spec.rb
+++ b/spec/requests/api/v1/courses_spec.rb
@@ -30,10 +30,12 @@ RSpec.describe 'API::V1::Courses', type: :request do
   describe 'POST /api/v1/courses' do
     context 'with valid parameters' do
       it 'renders a JSON response with the new course' do
+        attributes = attributes_for(:course).merge(sections_attributes: [attributes_for(:section)])
         expect do
           post api_v1_courses_url,
-               params: { course: attributes_for(:course) }, as: :json
+               params: { course: attributes }, as: :json
         end.to change(Course, :count).by(1)
+           .and change(Section, :count).by(1)
         expect(response).to have_http_status(201)
         expect(response.content_type).to match(a_string_including('application/json'))
       end
@@ -66,7 +68,7 @@ RSpec.describe 'API::V1::Courses', type: :request do
     context 'with valid parameters' do
       it 'updates the requested course and responds with http status 200' do
         course = create(:course)
-        attributes = attributes_for(:course)
+        attributes = attributes_for(:course).merge(sections_attributes: [attributes_for(:section)])
         patch api_v1_course_url(course), params: { course: attributes }, as: :json
         expect(response).to have_http_status(200)
         expect(response.content_type).to match(a_string_including('application/json'))
@@ -96,7 +98,10 @@ RSpec.describe 'API::V1::Courses', type: :request do
 
     it 'destroys the requested course' do
       course = create(:course)
-      expect { delete api_v1_course_url(course), as: :json }.to change(Course, :count).by(-1)
+      create(:section, course: course)
+      expect { delete api_v1_course_url(course), as: :json }
+        .to change(Course, :count).by(-1)
+        .and change(Section, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
Please feel free to remove unnecessary items in check list

## WIP Checklist

- [x] Kanban card link filled in
- [x] PR tagged with correct milestone(Same as sprint name)
- [x] New rspec tests for new code written
- [x] Manual testing done
- [x] Changelog updated
- [x] Corresponding labels added(db:migrate, rake task)
- [ ] Parent ticket branch as PR comparison base specified

## Why is this change necessary?

- Build sections for courses

## How does it address the issue?

- Add a new ORM class `app/models/section.rb` and related db table
- Build associations between `app/models/course.rb` and `app/models/section.rb`

## What side effects does this change have?
Side effect is to describe "Is there anything gonna be effected by the subject of this change".
- e.g. Performance
- You name it

## Related PRs?

* other_pr_production / link

## Deploy Notes

- DB schema migrate:
  - `rails db:migrate`
- Rake tasks:
- Config (secrets in blackbox/VAULT):

## Template for descriptions of PR re-submitting
> The latest changes from **_{the link of the starting commit of the change}_** has following updates:
> - changes description 
