### PR TITLE
5-user-can-manage-courses-with-lessons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
     - `rails db:migrate`
   - [4-user-can-manage-courses-with-sections](https://trello.com/c/GOKlj5sG)
     - `rails db:migrate`
+  - [5-user-can-manage-courses-with-lessons](https://trello.com/c/W2Z7m1At)
+    - `rails db:migrate`
 - Improvements
 - Bug fixes
 - Growth

--- a/app/controllers/api/v1/courses_controller.rb
+++ b/app/controllers/api/v1/courses_controller.rb
@@ -32,6 +32,10 @@ class API::V1::CoursesController < API::BaseController
   end
 
   def course_params
-    params.require(:course).permit(:name, :teacher_name, :description, sections_attributes: [:id, :name, :position, :_destroy])
+    params.require(:course).permit(:name, :teacher_name, :description,
+                                   sections_attributes: [
+                                     :id, :name, :position, :_destroy,
+                                     { lessons_attributes: [ :id, :name, :description, :content, :position, :_destroy] }
+                                   ])
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,7 +1,8 @@
 class Course < ApplicationRecord
   extend ::FriendlyId
   friendly_id :name_and_date_of_today, use: :slugged
-  has_many :sections, dependent: :delete_all
+  has_many :sections, dependent: :destroy
+  has_many :lessons, through: :sections
   validates_presence_of :name, :teacher_name
   accepts_nested_attributes_for :sections, allow_destroy: true
 

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,0 +1,5 @@
+class Lesson < ApplicationRecord
+  belongs_to :section
+  acts_as_list scope: :section, top_of_list: 0
+  validates_presence_of :name, :content
+end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,5 +1,6 @@
 class Section < ApplicationRecord
   belongs_to :course
+  has_many :lessons, dependent: :delete_all
   acts_as_list scope: :course, top_of_list: 0
   validates_presence_of :name, :position
   validates_uniqueness_of :position, scope: :course_id
@@ -7,4 +8,5 @@ class Section < ApplicationRecord
   # it converts negative value of position to zero automatically
   # https://github.com/brendon/acts_as_list/issues/269
   # validates_numericality_of :position, greater_than_or_equal_to: 0
+  accepts_nested_attributes_for :lessons, allow_destroy: true
 end

--- a/db/migrate/20220404072910_create_lessons.rb
+++ b/db/migrate/20220404072910_create_lessons.rb
@@ -1,0 +1,16 @@
+class CreateLessons < ActiveRecord::Migration[6.1]
+  def change
+    create_table :lessons do |t|
+      t.string :name
+      t.text :description
+      t.text :content, null: false
+      t.integer :position, default: 0, null: false
+      t.references :section, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :lessons, :name
+    add_index :lessons, [:section_id, :name]
+    add_index :lessons, [:section_id, :position]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_03_102934) do
+ActiveRecord::Schema.define(version: 2022_04_04_072910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,20 @@ ActiveRecord::Schema.define(version: 2022_04_03_102934) do
     t.index ["slug"], name: "index_courses_on_slug", unique: true
   end
 
+  create_table "lessons", force: :cascade do |t|
+    t.string "name"
+    t.text "description"
+    t.text "content", null: false
+    t.integer "position", default: 0, null: false
+    t.bigint "section_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_lessons_on_name"
+    t.index ["section_id", "name"], name: "index_lessons_on_section_id_and_name"
+    t.index ["section_id", "position"], name: "index_lessons_on_section_id_and_position"
+    t.index ["section_id"], name: "index_lessons_on_section_id"
+  end
+
   create_table "sections", force: :cascade do |t|
     t.string "name", null: false
     t.integer "position", default: 0, null: false
@@ -36,5 +50,6 @@ ActiveRecord::Schema.define(version: 2022_04_03_102934) do
     t.index ["course_id"], name: "index_sections_on_course_id"
   end
 
+  add_foreign_key "lessons", "sections"
   add_foreign_key "sections", "courses"
 end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :lesson do
+    name { Faker::Hobby.activity }
+    description { Faker::Lorem.word }
+    content { Faker::Hobby.activity }
+    position { 0 }
+    section
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Course, type: :model do
   describe 'associations' do
-    it { should have_many(:sections).dependent(:delete_all) }
+    it { should have_many(:sections).dependent(:destroy) }
+    it { should have_many(:lessons) }
   end
 
   describe 'validations' do

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe Lesson, type: :model do
+  describe 'associations' do
+    it { should belong_to(:section) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:content) }
+  end
+end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Section, type: :model do
   describe 'associations' do
     it { should belong_to(:course) }
+    it { should have_many(:lessons).dependent(:delete_all) }
   end
 
   describe 'validations' do
@@ -27,7 +28,9 @@ RSpec.describe Section, type: :model do
         # expect(section).to validate_numericality_of(:position).is_greater_than_or_equal_to(0)
       end
     end
+  end
 
-
+  describe 'nested_attributes' do
+    it { should accept_nested_attributes_for(:lessons).allow_destroy(true) }
   end
 end

--- a/spec/requests/api/v1/courses_spec.rb
+++ b/spec/requests/api/v1/courses_spec.rb
@@ -30,12 +30,18 @@ RSpec.describe 'API::V1::Courses', type: :request do
   describe 'POST /api/v1/courses' do
     context 'with valid parameters' do
       it 'renders a JSON response with the new course' do
-        attributes = attributes_for(:course).merge(sections_attributes: [attributes_for(:section)])
+        attributes =
+          attributes_for(:course).merge(
+            sections_attributes: [attributes_for(:section).merge(
+              lessons_attributes: [attributes_for(:lesson)]
+            )]
+          )
         expect do
           post api_v1_courses_url,
                params: { course: attributes }, as: :json
         end.to change(Course, :count).by(1)
            .and change(Section, :count).by(1)
+           .and change(Lesson, :count).by(1)
         expect(response).to have_http_status(201)
         expect(response.content_type).to match(a_string_including('application/json'))
       end
@@ -68,7 +74,12 @@ RSpec.describe 'API::V1::Courses', type: :request do
     context 'with valid parameters' do
       it 'updates the requested course and responds with http status 200' do
         course = create(:course)
-        attributes = attributes_for(:course).merge(sections_attributes: [attributes_for(:section)])
+        attributes =
+          attributes_for(:course).merge(
+            sections_attributes: [attributes_for(:section).merge(
+              lessons_attributes: [attributes_for(:lesson)]
+            )]
+          )
         patch api_v1_course_url(course), params: { course: attributes }, as: :json
         expect(response).to have_http_status(200)
         expect(response.content_type).to match(a_string_including('application/json'))
@@ -98,10 +109,12 @@ RSpec.describe 'API::V1::Courses', type: :request do
 
     it 'destroys the requested course' do
       course = create(:course)
-      create(:section, course: course)
+      section = create(:section, course: course)
+      create(:lesson, section: section)
       expect { delete api_v1_course_url(course), as: :json }
         .to change(Course, :count).by(-1)
         .and change(Section, :count).by(-1)
+        .and change(Lesson, :count).by(-1)
     end
   end
 end


### PR DESCRIPTION
Please feel free to remove unnecessary items in check list

## WIP Checklist

- [x] Kanban card link filled in
- [x] PR tagged with correct milestone(Same as sprint name)
- [x] New rspec tests for new code written
- [x] Manual testing done
- [x] Changelog updated
- [x] Corresponding labels added(db:migrate, rake task)
- [ ] Parent ticket branch as PR comparison base specified

## Why is this change necessary?

- Build lessons for sections and courses.

## How does it address the issue?

- Add a new ORM class `app/models/lesson.rb` and related db table
- Build associations between `app/models/course.rb`, `app/models/section.rb` and `app/models/lesson.rb`

## What side effects does this change have?
Side effect is to describe "Is there anything gonna be effected by the subject of this change".
- e.g. Performance
- You name it

## Related PRs?

* other_pr_production / link

## Deploy Notes

- DB schema migrate:
  - `rails db:migrate`
- Rake tasks:
- Config (secrets in blackbox/VAULT):

## Template for descriptions of PR re-submitting
> The latest changes from **_{the link of the starting commit of the change}_** has following updates:
> - changes description 
